### PR TITLE
fix: fix committed files not traced problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,26 +7,38 @@ TRACER = tracer-ysyx2204
 GITFLAGS = -q --author='$(TRACER) <tracer@ysyx.org>' --no-verify --allow-empty
 
 YSYX_HOME = $(NEMU_HOME)/..
+WORK_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+WORK_INDEX = $(YSYX_HOME)/.git/index.$(WORK_BRANCH)
 TRACER_BRANCH = $(TRACER)
+
+LOCK_DIR = $(YSYX_HOME)/.git/
+
+# prototype: git_soft_checkout(branch)
+define git_soft_checkout
+	git checkout --detach -q && git reset --soft $(1) -q && git checkout $(1) -q
+endef
 
 # prototype: git_commit(msg)
 define git_commit
-	-@cd $(YSYX_HOME) && while (test -e .git/index.lock); do sleep 0.1; done;  `# wait for other git instances`
-	-@cd $(YSYX_HOME) && git branch $(TRACER_BRANCH) -q 2>/dev/null || true    `# create tracer branch if not existent`
-	-@cd $(YSYX_HOME) && git worktree add $(TRACER_BRANCH) -q                  `# check out tracer branch`
-	-@cd $(YSYX_HOME) && git status --untracked-files -z                       `# list changed files to copy (w/o quotes)` \
-			| tr '\000' '\n'                                           `# restore EOL sequence`                    \
-			| cut -c 1-3 --complement                                  `# remove status indicator`                 \
-			| grep -v '^$(TRACER_BRANCH)/'                             `# skip tracer worktree`                    \
-			| rsync -aq --files-from=- ./ $(TRACER_BRANCH)/            `# call rsync to copy files`
-	-@cd $(YSYX_HOME) && git -C $(TRACER_BRANCH) add . -A --ignore-errors      `# add changes to staging area`
-	-@cd $(YSYX_HOME) && (echo "> $(1)" && echo $(STUID) $(STUNAME) && uname -a && uptime `# generate commit msg`)         \
-			| git -C $(TRACER_BRANCH) commit -F - $(GITFLAGS)          `# commit changes in tracer branch`
-	-@cd $(YSYX_HOME) && git worktree remove $(TRACER_BRANCH) -f               `# remove tracer worktree`
+	-@flock $(LOCK_DIR) $(MAKE) .git_commit MSG='$(1)'
 	-@sync
 endef
+
+.git_commit:
+	-@cd $(YSYX_HOME) && while (test -e .git/index.lock); do sleep 0.1; done;               `# wait for other git instances`
+	-@cd $(YSYX_HOME) && git branch $(TRACER_BRANCH) -q 2>/dev/null || true                 `# create tracer branch if not existent`
+	-@cd $(YSYX_HOME) && cp -a .git/index $(WORK_INDEX)                                     `# backup git index`
+	-@cd $(YSYX_HOME) && $(call git_soft_checkout, $(TRACER_BRANCH))                        `# switch to tracer branch`
+	-@cd $(YSYX_HOME) && git add . -A --ignore-errors                                       `# add files to commit`
+	-@cd $(YSYX_HOME) && (echo "> $(MSG)" && echo $(STUID) $(STUNAME) && uname -a && uptime `# generate commit msg`) \
+	                | git commit -F - $(GITFLAGS)                                           `# commit changes in tracer branch`
+	-@cd $(YSYX_HOME) && $(call git_soft_checkout, $(WORK_BRANCH))                          `# switch to work branch`
+	-@cd $(YSYX_HOME) && mv $(WORK_INDEX) .git/index                                        `# restore git index`
+
+.clean_index:
+	rm -f $(WORK_INDEX)
 
 _default:
 	@echo "Please run 'make' under subprojects."
 
-.PHONY: _default
+.PHONY: .git_commit .clean_index _default


### PR DESCRIPTION
In this revision, we manually backup & restore `.git/index` file to keep staging area intact when switching back and forth.

This should work well if only one `make` instance is running. But if `make` is invoked with `-j` option,
say `make -C am-kernels/tests/cpu-tests/ ARCH=riscv64-nemu -j10`, the behavior will be unpredictable.

Do we need a more secure & complex locking mechanism, like `flock`?
