### PR TITLE
fix: handle revision and pathspec of same name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LOCK_DIR = $(YSYX_HOME)/.git/
 
 # prototype: git_soft_checkout(branch)
 define git_soft_checkout
-	git checkout --detach -q && git reset --soft $(1) -q && git checkout $(1) -q
+	git checkout --detach -q && git reset --soft $(1) -q -- && git checkout $(1) -q --
 endef
 
 # prototype: git_commit(msg)


### PR DESCRIPTION
`git reset` complains when a revision and a file has the same name:
```
fatal: ambiguous argument '...': both revision and filename
Use '--' to separate paths from revisions, like this:
git <command> [<revision>...] -- [<file>...]'
```
In this revision, `--` is added to the Git cmdline (both `reset` and `checkout`) after revision spec to clarify this ambiguity.