### PR TITLE
避免sync造成的不必要的阻塞

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endef
 # prototype: git_commit(msg)
 define git_commit
 	-@flock $(LOCK_DIR) $(MAKE) -C $(YSYX_HOME) .git_commit MSG='$(1)'
-	-@sync
+	-@sync $(LOCK_DIR)
 endef
 
 .git_commit:


### PR DESCRIPTION
针对问题:
我在使用rsync向机械硬盘备份大量数据时,执行ysyx中的make.而git_commit存在sync,导致make被阻塞,等待rsync拷贝结束.
这导致我在备份数据的时候几乎无法编写ysyx的相关内容

我认为解决方法也是很简单的,只需要针对需要的目录/文件进行同步即可
这是我将sync改成sync $(LOCK_DIR)的原因