### PR TITLE
fix: 改进 tracer 的工作区恢复逻辑(支持`detached HEAD`状态, 支持brach名称中包含`/`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,17 @@ STUNAME = 张三
 TRACER = tracer-ysyx
 GITFLAGS = -q --author='$(TRACER) <tracer@ysyx.org>' --no-verify --allow-empty
 
-YSYX_HOME = $(NEMU_HOME)/..
-WORK_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
-WORK_BRANCH_REF := $(shell git rev-parse --symbolic-full-name HEAD 2>/dev/null)
-WORK_BRANCH_HASH := $(shell printf '%s' '$(WORK_BRANCH_REF)' | git hash-object --stdin)
-WORK_INDEX := $(YSYX_HOME)/.git/index.$(WORK_BRANCH_HASH)
+YSYX_HOME     = $(NEMU_HOME)/..
+WORK_BRANCH   = $(shell git symbolic-ref -q --short HEAD 2>/dev/null)
+WORK_HEAD     = $(shell git rev-parse --verify HEAD 2>/dev/null)
+WORK_REF      = $(if $(WORK_BRANCH),$(WORK_BRANCH),$(WORK_HEAD))
+WORK_KEY      = $(shell printf '%s' '$(if $(WORK_BRANCH),b:$(WORK_BRANCH),h:$(WORK_HEAD))' | git hash-object --stdin)
+WORK_INDEX    = $(YSYX_HOME)/.git/index.$(WORK_KEY)
 TRACER_BRANCH = $(TRACER)
 
 LOCK_DIR = $(YSYX_HOME)/.git/
 
-# prototype: git_soft_checkout(branch)
+# prototype: git_soft_checkout(ref)
 define git_soft_checkout
 	git checkout --detach -q && git reset --soft $(1) -q -- && git checkout $(1) -q --
 endef
@@ -34,7 +35,7 @@ endef
 	-@git add . -A --ignore-errors                                       `# add files to commit`
 	-@(echo "> $(MSG)" && echo $(STUID) $(STUNAME) && uname -a && uptime `# generate commit msg`) \
 	                | git commit -F - $(GITFLAGS)                        `# commit changes in tracer branch`
-	-@$(call git_soft_checkout, $(WORK_BRANCH))                          `# switch to work branch`
+	-@$(call git_soft_checkout, $(WORK_REF))                             `# switch to work ref`
 	-@mv $(WORK_INDEX) .git/index                                        `# restore git index`
 
 .clean_index:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ GITFLAGS = -q --author='$(TRACER) <tracer@ysyx.org>' --no-verify --allow-empty
 
 YSYX_HOME = $(NEMU_HOME)/..
 WORK_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
-WORK_INDEX = $(YSYX_HOME)/.git/index.$(WORK_BRANCH)
+WORK_BRANCH_REF := $(shell git rev-parse --symbolic-full-name HEAD 2>/dev/null)
+WORK_BRANCH_HASH := $(shell printf '%s' '$(WORK_BRANCH_REF)' | git hash-object --stdin)
+WORK_INDEX := $(YSYX_HOME)/.git/index.$(WORK_BRANCH_HASH)
 TRACER_BRANCH = $(TRACER)
 
 LOCK_DIR = $(YSYX_HOME)/.git/


### PR DESCRIPTION
## 背景

当前 tracer 的实现有以下两个问题：

- 当分支名中包含 `/` 时，备份 Git index 的路径会出错，因为 `$(WORK_INDEX)` 会将 `/` 解释为目录分隔符
- 当仓库处于 `detached HEAD` 状态时，无法正确恢复原工作区状态，因为 `git rev-parse --abbrev-ref HEAD` 的结果为字面量`HEAD`，而不是实际可恢复的分支名
 
## 主要修改

- 不再直接使用分支名构造备份 index 路径，而是使用`git hash-object`来作为文件名的一部分
- 优先使用当前分支恢复工作区；如果处于 `detached HEAD` 状态，则回退到当前 `HEAD` 对应的提交