### PR TITLE
init: use shallow clone to speed up initialization

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -18,7 +18,7 @@ function init() {
   fi
 
   while [ ! -d $3 ]; do
-    git clone -b $2 git@github.com:$1.git $3
+    git clone --depth 1 -b $2 git@github.com:$1.git $3
   done
   log="$1 `cd $3 && git log --oneline --no-abbrev-commit -n1`"$'\n'
 


### PR DESCRIPTION
`init *** true` 的仓库会被删除.git, 全量下载没必要
`init *** false` 的仓库的仓库通常来说也不会去关心他的历史信息, 也没必要全量下载
此外还有一个关键问题, `archbench`太大了, 全量下载大概有2G.